### PR TITLE
fix AccessDenied text

### DIFF
--- a/booking/mixins.py
+++ b/booking/mixins.py
@@ -199,8 +199,8 @@ class BackMixin(ContextMixin):
 
 class AccessDenied(PermissionDenied):
     def __init__(self, text, *args, **kwargs):
-        _text = text
-        print _text.encode('utf-8')
+        self._text = text
+        print self._text.encode('utf-8')
         return super(AccessDenied, self).__init__(text, *args, **kwargs)
 
     def __unicode__(self):


### PR DESCRIPTION
make `_text` an attribute on the object so the `__unicode__` method doesn't error out