### PR TITLE
[33539] add no start and end filtering for Statistics

### DIFF
--- a/profile/forms.py
+++ b/profile/forms.py
@@ -124,12 +124,14 @@ class StatisticsForm(forms.Form):
             attrs={
                 'class': 'form-control input-sm datepicker datepicker-admin'
             }
-        )
+        ),
+        required=False
     )
     to_date = forms.DateField(
         widget=forms.TextInput(
             attrs={
                 'class': 'form-control input-sm datepicker datepicker-admin'
             }
-        )
+        ),
+        required=False
     )

--- a/profile/views.py
+++ b/profile/views.py
@@ -762,8 +762,10 @@ class StatisticsView(EditorRequiredMixin, BreadcrumbMixin, TemplateView):
                 )
             if not from_date and not to_date:
                 qs = qs.filter(
-                    (Q(visit__eventtime__start__isnull=True) & Q(visit__cancelled_eventtime__start__isnull=True)) &
-                    (Q(visit__eventtime__end__isnull=True) & Q(visit__cancelled_eventtime__end__isnull=True))
+                    (Q(visit__eventtime__start__isnull=True) &
+                        Q(visit__cancelled_eventtime__start__isnull=True)) &
+                    (Q(visit__eventtime__end__isnull=True) &
+                        Q(visit__cancelled_eventtime__end__isnull=True))
                 )
             qs = qs.order_by('visit__eventtime__product__pk')
             context['bookings'] = qs

--- a/profile/views.py
+++ b/profile/views.py
@@ -760,6 +760,11 @@ class StatisticsView(EditorRequiredMixin, BreadcrumbMixin, TemplateView):
                     Q(visit__eventtime__end__lt=to_date) |
                     Q(visit__cancelled_eventtime__end__lt=to_date)
                 )
+            if not from_date and not to_date:
+                qs = qs.filter(
+                    (Q(visit__eventtime__start__isnull=True) & Q(visit__cancelled_eventtime__start__isnull=True)) &
+                    (Q(visit__eventtime__end__isnull=True) & Q(visit__cancelled_eventtime__end__isnull=True))
+                )
             qs = qs.order_by('visit__eventtime__product__pk')
             context['bookings'] = qs
         context.update(kwargs)

--- a/profile/views.py
+++ b/profile/views.py
@@ -762,10 +762,10 @@ class StatisticsView(EditorRequiredMixin, BreadcrumbMixin, TemplateView):
                 )
             if not from_date and not to_date:
                 qs = qs.filter(
-                    (Q(visit__eventtime__start__isnull=True) &
-                        Q(visit__cancelled_eventtime__start__isnull=True)) &
-                    (Q(visit__eventtime__end__isnull=True) &
-                        Q(visit__cancelled_eventtime__end__isnull=True))
+                    visit__eventtime__start__isnull=True,
+                    visit__cancelled_eventtime__start__isnull=True,
+                    visit__eventtime__end__isnull=True,
+                    visit__cancelled_eventtime__end__isnull=True
                 )
             qs = qs.order_by('visit__eventtime__product__pk')
             context['bookings'] = qs


### PR DESCRIPTION
- make `start_date` and `end_date` on `StatisticsForm` optional
- if no `start_date` and `end_date` are given search for visits without start and end dates.